### PR TITLE
Capybaraの無効化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ end
 
 group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
-  gem "capybara"
+  # gem "capybara"
   gem "selenium-webdriver"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,6 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
@@ -87,15 +85,6 @@ GEM
     brakeman (7.0.2)
       racc
     builder (3.3.0)
-    capybara (3.40.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.11)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     crass (1.0.6)
@@ -156,7 +145,6 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
-    matrix (0.4.2)
     mini_mime (1.1.5)
     minitest (5.25.5)
     msgpack (1.8.0)
@@ -209,7 +197,6 @@ GEM
     psych (5.2.5)
       date
       stringio
-    public_suffix (6.0.2)
     puma (6.6.0)
       nio4r (~> 2.0)
     raabro (1.4.0)
@@ -383,8 +370,6 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
     zeitwerk (2.7.2)
 
 PLATFORMS
@@ -402,7 +387,6 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   brakeman
-  capybara
   debug
   factory_bot_rails
   foreman


### PR DESCRIPTION
## 変更内容
Capybaraを無効化。

## なぜ？
- `bundle exec rspec`をやったときに、
`/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/capybara-3.40.0/lib/capybara/session/config.rb:95: warning: URI::RFC3986_PARSER.make_regexp is obsolete. Use URI::RFC2396_PARSER.make_regexp explicitly.`
のwarningが出ており、最新バージョンでも改善されていないため。
- 現状使用していないため。必要になったら再度有効化するか、代替できるものを探す。